### PR TITLE
CI config tweaking

### DIFF
--- a/.github/workflows/cloud-client-tests.yml
+++ b/.github/workflows/cloud-client-tests.yml
@@ -7,6 +7,8 @@ jobs:
   cloud-client-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
+      max-parallel: 1
       matrix:
         cloud-client-version:
           - 'releases/latest'


### PR DESCRIPTION
Don't run test configurations in parallel. Also continue to run other
configurations even if one fails.
