### PR TITLE
Temporarily disable tests with trunk ucm builds

### DIFF
--- a/.github/workflows/cloud-client-tests.yml
+++ b/.github/workflows/cloud-client-tests.yml
@@ -20,7 +20,8 @@ jobs:
           - 'main'
         ucm-release-version:
           - 'release%2F0.5.25'
-          - 'trunk-build'
+          # temporarily disabling until known issue is resolved
+          #- 'trunk-build'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
Until the issue caused by the recent trunk merge is resolved.
