### PR TITLE
Log `ucm` version in `run-tests.sh`

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -18,6 +18,7 @@ run_transcript() {
   esac
 }
 
+ucm version # just to show it in the log
 run_transcript || exit_status=$?
 cat cloud-tests.output.md
 


### PR DESCRIPTION
Add `ucm version` logging to test script.

Motivation: I wanted to be sure of what version was passing before doing a ucm release.